### PR TITLE
add Thai language file.

### DIFF
--- a/src/lang/th/date.php
+++ b/src/lang/th/date.php
@@ -1,0 +1,48 @@
+<?php
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Date Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the date library. Each line can
+    | have a singular and plural translation separated by a '|'.
+    |
+    */
+
+    'ago'       => ':time ที่แล้ว',
+    'from_now'  => ':time จากนี้',
+    'after'     => 'หลัง:time',
+    'before'    => 'ก่อน:time',
+    'year'      => '1 ปี|:count ปี',
+    'month'     => '1 เดือน|:count เดือน',
+    'week'      => '1 สัปดาห์|:count สัปดาห์',
+    'day'       => '1 วัน|:count วัน',
+    'hour'      => '1 ชั่วโมง|:count ชั่วโมง',
+    'minute'    => '1 นาที|:count นาที',
+    'second'    => '1 วินาที|:count วินาที',
+
+    'january'   => 'มกราคม',
+    'february'  => 'กุมภาพันธ์',
+    'march'     => 'มีนาคม',
+    'april'     => 'เมษายน',
+    'may'       => 'พฤษภาคม',
+    'june'      => 'มิถุนายน',
+    'july'      => 'กรกฎาคม',
+    'august'    => 'สิงหาคม',
+    'september' => 'กันยายน',
+    'october'   => 'ตุลาคม',
+    'november'  => 'พฤศจิกายน',
+    'december'  => 'ธันวาคม',
+
+    'monday'    => 'จันทร์',
+    'tuesday'   => 'อังคาร',
+    'wednesday' => 'พุธ',
+    'thursday'  => 'พฤหัสบดี',
+    'friday'    => 'ศุกร์',
+    'saturday'  => 'เสาร์',
+    'sunday'    => 'อาทิตย์',
+
+);


### PR DESCRIPTION
However, in Thai, we do not use the first 3 letters for month and day abbreviations.
Instead, we have predefined abbreviations for months and days, like so:

```php
// month abbreviations
'jan' => 'ม.ค.',
'feb' => 'ก.พ.',
'mar' => 'มี.ค.',
'apr' => 'เม.ย.',
'may' => 'พ.ค.',
'jun' => 'มิ.ย.',
'jul' => 'ก.ค.',
'aug' => 'ส.ค.',
'sep' => 'ก.ย.',
'oct' => 'ต.ค.',
'nov' => 'พ.ย.',
'dec' => 'ธ.ค.',

// day abbr.
'mon' => 'จ.',
'tue' => 'อ.',
'wed' => 'พ.',
'thu' => 'พฤ.',
'fri' => 'ศ.',
'sat' => 'ส.',
'sun' => 'อา.',

```

And Thai uses Buddhist calender which equivalent to the Western Year + 543.
For example, 2014 (Western Year) = 2557 (Buddhist Year)

