### PR TITLE
Fix for missing 0/5+ weeks for Slovenian, fix for multibyte internationa...

### DIFF
--- a/src/lang/sl/date.php
+++ b/src/lang/sl/date.php
@@ -11,26 +11,26 @@ return array(
 	| have a singular and plural translation separated by a '|'.
 	|
 	*/
-
+	
 	'ago'       => 'pred :time',
 	'from_now'  => 'čez :time',
 	'after'     => 'čez :time',
 	'before'    => 'pred :time',
-	'year'      => ':count leto|:count leto|:count leti|:count leta|:count let',
-	'month'     => ':count mesec|:count mesec|:count meseca|:count mesece|:count mesecev',
-	'week'      => ':count teden|:count teden|:count tedna|:count tedne',
-	'day'       => ':count dan|:count dan|:count dni|:count dni|:count dni',
-	'hour'      => ':count uro|:count uro|:count uri|:count ure|:count ur',
-	'minute'    => ':count minuto|:count minuto|:count minuti|:count minute|:count minut',
-	'second'    => ':count sekundo|:count sekundo|:count sekundi|:count sekunde|:count sekund',
-	'year_ago'  => ':count letom|:count letom|:count leti|:count leti|:count leti',
-	'month_ago' => ':count mesecem|:count mesecem|:count meseci|:count meseci|:count meseci',
-	'week_ago'  => ':count tednom|:count tednom|:count tedni|:count tedni',
-	'day_ago'   => ':count dnem|:count dnem|:count dnevoma|:count dnevi|:count dnevi',
-	'hour_ago'  => ':count uro|:count uro|:count urama|:count urami|:count urami',
-	'minute_ago'=> ':count minuto|:count minuto|:count minutama|:count minutami',
-	'second_ago'=> ':count sekundo|:count sekundo|:count sekundama|:count sekundami|:count sekundami',
-
+	'year'      => '1 leto|:count leti|:count leta|:count let',
+	'month'     => '1 mesec|:count meseca|:count mesece|:count mesecev',
+	'week'      => '1 teden|:count tedna|:count tedne|:count tednov',
+	'day'       => '1 dan|:count dni|:count dni|:count dni',
+	'hour'      => '1 uro|:count uri|:count ure|:count ur',
+	'minute'    => '1 minuto|:count minuti|:count minute|:count minut',
+	'second'    => '1 sekundo|:count sekundi|:count sekunde|:count sekund',
+	'year_ago'  => '1 letom|:count leti|:count leti|:count leti',
+	'month_ago' => '1 mesecem|:count meseci|:count meseci|:count meseci',
+	'week_ago'  => '1 tednom|:count tedni|:count tedni',
+	'day_ago'   => '1 dnem|:count dnevoma|:count dnevi|:count dnevi',
+	'hour_ago'  => '1 uro|:count urama|:count urami|:count urami',
+	'minute_ago'=> '1 minuto|:count minutama|:count minutami',
+	'second_ago'=> '1 sekundo|:count sekundama|:count sekundami|:count sekundami',
+	
 	'january'   => 'januar',
 	'february'  => 'februar',
 	'march'     => 'marec',
@@ -43,7 +43,7 @@ return array(
 	'october'   => 'oktober',
 	'november'  => 'november',
 	'december'  => 'december',
-
+	
 	'monday'    => 'ponedeljek',
 	'tuesday'   => 'torek',
 	'wednesday' => 'sreda',

--- a/tests/AutomaticTest.php
+++ b/tests/AutomaticTest.php
@@ -39,7 +39,7 @@ class AutomaticTest extends PHPUnit_Framework_TestCase {
 
                 $this->assertTrue(isset($translations[$month]));
                 $this->assertEquals($translations[$month], $date->format('F'), "Language: $language"); // Full
-                $this->assertEquals(substr($translations[$month], 0 , 3), $date->format('M'), "Language: $language"); // Short
+                $this->assertEquals(mb_substr($translations[$month], 0 , 3), $date->format('M'), "Language: $language"); // Short
             }
         }
     }
@@ -67,7 +67,7 @@ class AutomaticTest extends PHPUnit_Framework_TestCase {
 
                 $this->assertTrue(isset($translations[$day]));
                 $this->assertEquals($translations[$day], $date->format('l'), "Language: $language"); // Full
-                $this->assertEquals(substr($translations[$day], 0 , 3), $date->format('D'), "Language: $language"); // Short
+                $this->assertEquals(mb_substr($translations[$day], 0 , 3), $date->format('D'), "Language: $language"); // Short
             }
         }
     }


### PR DESCRIPTION
...l characters in tests

Your fixes for Slovenian weren't correct, there was a missing argument on the end of the list for the form of "0 weeks, 5 weeks, 6 weeks, ..). Your tests also failed for languages with multibyte characters (ar, bg, cs, ....), I fixed that with mb_substr, all tests succeed now. There is also an odd test case for testing "0 weeks" output, which would never happen as it is converted to "0 seconds" instead.