### PR TITLE
Add version numbers to dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,33 @@
 {
     "name": "jenssegers/date",
     "description": "A date library to help you work with dates in different languages",
-    "keywords": ["laravel","date","time","datetime","i18n","translation"],
+    "keywords": ["laravel", "date", "time", "datetime", "i18n", "translation", "carbon"],
+    "license" : "MIT",
     "authors": [
         {
             "name": "Jens Segers",
             "homepage": "http://jenssegers.be"
         }
     ],
-    "license" : "MIT",
     "require": {
-        "php": ">=5.3.0",
-        "nesbot/Carbon": "*",
-        "symfony/translation": "*"
+        "php": ">=5.3.3",
+        "nesbot/carbon": "~1.0",
+        "symfony/translation": "~2.0"
     },
     "require-dev": {
-        "satooshi/php-coveralls": "*",
-        "phpunit/phpunit":"*"
+        "phpunit/phpunit": "~4.0",
+        "satooshi/php-coveralls": "0.6.*"
     },
     "autoload": {
         "psr-0": {
             "Jenssegers\\Date": "src/"
         }
-    }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0-dev"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
Also update the least php requirement since phpunit requires `>= 5.3.3`.

Added `branch-alias` to let developers install the latest version with `3.0.*@dev` as version number.