### PR TITLE
Fix bug for "0 seconds ago" in Czech and Slovak

### DIFF
--- a/src/Lang/cs.php
+++ b/src/Lang/cs.php
@@ -51,5 +51,5 @@ return array(
     'day_ago'       => 'jedním dnem|[2,Inf]:count dny',
     'hour_ago'      => 'hodinou|[2,Inf]:count hodinami',
     'minute_ago'    => 'minutou|[2,Inf]:count minutami',
-    'second_ago'    => 'sekundou|[2,Inf]:count sekundami',
+    'second_ago'    => '{0}0 sekundami|{1}sekundou|[2,Inf]:count sekundami',
 );

--- a/src/Lang/sk.php
+++ b/src/Lang/sk.php
@@ -51,6 +51,6 @@ return array(
     'day_ago'       => 'dňom|[2,Inf]:count dňami',
     'hour_ago'      => 'hodinou|[2,Inf]:count hodinami',
     'minute_ago'    => 'minútou|[2,Inf]:count minútami',
-    'second_ago'    => 'sekundou|[2,Inf]:count sekundami',
+    'second_ago'    => '{0}0 sekundami|{1}sekundou|[2,Inf]:count sekundami',
 
 );


### PR DESCRIPTION
Fixed bug where using diffForHumans() with current time would result in following error:
```
Unable to choose a translation for "sekundou|[2,Inf]:count sekundami" with locale "cs" for value "0".
```
I guess that the same error is in Slovenian language file.